### PR TITLE
Set GLTF flags and extensions to load VRM models correctly

### DIFF
--- a/screens/context.gd
+++ b/screens/context.gd
@@ -89,18 +89,7 @@ func _init(p_runner_data: RunnerData) -> void:
 				r.model = puppet
 			"vrm":
 				_logger.info("Loading vrm")
-				
-				var gltf := GLTFDocument.new()
-				var state := GLTFState.new()
-				
-				_logger.debug("append from file")
-				var err := gltf.append_from_file(model_path, state)
-				if err != OK:
-					_logger.error("Unable to load model from path {0}".format([model_path]))
-					return r
-				
-				_logger.debug("generate scene")
-				var loaded_model: Node = gltf.generate_scene(state)
+				var loaded_model: Node = ModelImporter.import_model_vrm(model_path)
 				if loaded_model == null:
 					_logger.error("Failed to generate scene for model {0}".format([model_path]))
 					return r

--- a/screens/model_importer.gd
+++ b/screens/model_importer.gd
@@ -1,0 +1,76 @@
+class_name ModelImporter
+
+static func import_model_infer_extension(model_path: String) -> Node3D:
+	if model_path.ends_with(".vrm"):
+		return ModelImporter.import_model_vrm(model_path)
+	elif model_path.ends_with(".gltf"):
+		return ModelImporter.import_model_gltf(model_path)
+	elif model_path.ends_with(".import"):
+		return ModelImporter.import_model_scene(model_path)
+	
+	print("Can't import model \'%s\' (Unknown type)" % model_path)
+	return null
+
+static func import_model_scene(model_path: String) -> Node3D:
+	print("Import scene: " + model_path)
+	return load(model_path.split(".import")[0]).instantiate()
+
+static func import_model_vrm(model_path: String) -> Node3D:
+	### Load a model from a given file path. Code taken from addons/vrm/import_vrm:_import_scene()
+	print("Import VRM: " + model_path)
+	
+	var gltf: GLTFDocument = GLTFDocument.new()
+	var vrm_extensions: Array[GLTFDocumentExtension] = _register_vrm_extensions()
+	
+	# Load model scene
+	var generated_scene = ModelImporter._import_model_gltf(model_path, gltf)
+	
+	_unregister_vrm_extensions(vrm_extensions)
+	return generated_scene
+
+static func import_model_gltf(model_path: String) -> Node3D:
+	print("Import GLTF: " + model_path)
+	var gltf: GLTFDocument = GLTFDocument.new()
+	return ModelImporter._import_model_gltf(model_path, gltf)
+
+static func _import_model_gltf(model_path: String, gltf: GLTFDocument) -> Node3D:
+	var flags: int = EditorSceneFormatImporter.IMPORT_USE_NAMED_SKIN_BINDS | \
+		EditorSceneFormatImporter.IMPORT_GENERATE_TANGENT_ARRAYS | \
+		EditorSceneFormatImporter.IMPORT_ANIMATION
+	var state: GLTFState = GLTFState.new()
+	# HANDLE_BINARY_EMBED_AS_BASIS crashes on some files in 4.0 and 4.1
+	state.handle_binary_image = GLTFState.HANDLE_BINARY_EMBED_AS_UNCOMPRESSED  # GLTFState.HANDLE_BINARY_EXTRACT_TEXTURES
+	
+	var err = gltf.append_from_file(model_path, state, flags)
+	if err != OK:
+		return null
+	
+	# Load model scene
+	var generated_scene = gltf.generate_scene(state)
+	return generated_scene
+
+static func _register_vrm_extensions() -> Array[GLTFDocumentExtension]:
+	### Initialize GLTF VRM extensions before loading vrm
+	var extensions: Array[GLTFDocumentExtension] = []
+	extensions.append(preload("res://addons/vrm/vrm_extension.gd").new())
+	
+	for ext in extensions:
+		GLTFDocument.register_gltf_document_extension(ext, true)
+	
+	var secondary_extensions: Array[GLTFDocumentExtension] = []
+	secondary_extensions.append(preload("res://addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd").new())
+	secondary_extensions.append(preload("res://addons/vrm/1.0/VRMC_materials_mtoon.gd").new())
+	secondary_extensions.append(preload("res://addons/vrm/1.0/VRMC_node_constraint.gd").new())
+	secondary_extensions.append(preload("res://addons/vrm/1.0/VRMC_springBone.gd").new())
+	secondary_extensions.append(preload("res://addons/vrm/1.0/VRMC_vrm.gd").new())
+	
+	for ext in secondary_extensions:
+		GLTFDocument.register_gltf_document_extension(ext)
+	
+	return extensions + secondary_extensions
+
+static func _unregister_vrm_extensions(vrm_extensions: Array[GLTFDocumentExtension]):
+	### Unregister GLTF VRM extensions after loading vrm
+	vrm_extensions.reverse()
+	for ext in vrm_extensions:
+		GLTFDocument.unregister_gltf_document_extension(ext)

--- a/screens/splash.gd
+++ b/screens/splash.gd
@@ -104,13 +104,6 @@ func _ready() -> void:
 			_logger.error("Unable to load metadata!")
 			metadata = Metadata.new()
 		AM.metadata = metadata
-		
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/vrm_extension.gd").new(), true)
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/1.0/VRMC_materials_hdr_emissiveMultiplier.gd").new())
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/1.0/VRMC_materials_mtoon.gd").new())
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/1.0/VRMC_node_constraint.gd").new())
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/1.0/VRMC_springBone.gd").new())
-		GLTFDocument.register_gltf_document_extension(preload("res://addons/vrm/1.0/VRMC_vrm.gd").new())
 	)
 	
 	_logger.debug("Splash ready!")


### PR DESCRIPTION
When loading old VRM 0.x models, the current import method doesn't load a model's head. 
![load_incorrect](https://github.com/VTuxers/VPupPr-im/assets/102542997/19463b93-0e3f-4746-8339-bcfca913b20a)


By setting the correct GLTF flags and loading the correct extensions, the models can be loaded correctly.
![load_correct](https://github.com/VTuxers/VPupPr-im/assets/102542997/d7639e55-6b8d-4c73-bf6e-a467797c20f8)
